### PR TITLE
Unwrap NativeJavaObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 alfresco-jscript-extensions
 ===========================
 
-Alfresco 5.1 (Master) [![Build Status](https://travis-ci.org/jgoldhammer/alfresco-jscript-extensions.svg?branch=master)](https://travis-ci.org/jgoldhammer/alfresco-jscript-extensions)
+Alfresco 5.1 (Master) [![Build Status](https://travis-ci.org/ecm4u/alfresco-jscript-extensions.svg?branch=master)](https://travis-ci.org/jgoldhammer/alfresco-jscript-extensions)
 
-Alfresco 5.0.d (Build-4.2) [![Build Status](https://travis-ci.org/jgoldhammer/alfresco-jscript-extensions.svg?branch=build-4.2)](https://travis-ci.org/jgoldhammer/alfresco-jscript-extensions)
+Alfresco 5.0.d (Build-4.2) [![Build Status](https://travis-ci.org/ecm4u/alfresco-jscript-extensions.svg?branch=build-4.2)](https://travis-ci.org/jgoldhammer/alfresco-jscript-extensions)
 
 Alfresco repository module with helpful javascript root object extensions which are helpful in much scenarios.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 alfresco-jscript-extensions
 ===========================
 
-Alfresco 5.1 (Master) [![Build Status](https://travis-ci.org/ecm4u/alfresco-jscript-extensions.svg?branch=master)](https://travis-ci.org/jgoldhammer/alfresco-jscript-extensions)
+Alfresco 5.1 (Master) [![Build Status](https://travis-ci.org/ecm4u/alfresco-jscript-extensions.svg?branch=master)](https://travis-ci.org/ecm4u/alfresco-jscript-extensions)
 
 Alfresco 5.0.d (Build-4.2) [![Build Status](https://travis-ci.org/ecm4u/alfresco-jscript-extensions.svg?branch=build-4.2)](https://travis-ci.org/jgoldhammer/alfresco-jscript-extensions)
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,9 +43,6 @@
     </developers>
 
     <properties>
-
-        <sonatypeOssDistMgmtSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</sonatypeOssDistMgmtSnapshotsUrl>
-
             <!-- Alfresco Maven Plugin version to use -->
             <alfresco.sdk.version>3.0.0-beta-4</alfresco.sdk.version>
 
@@ -372,19 +369,6 @@
             <id>release</id>
             <build>
                 <plugins>
-                    <!-- plugin for publishing maven artifacts-->
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.7</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                        </configuration>
-                    </plugin>
-
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
@@ -412,57 +396,6 @@
                             </execution>
                         </executions>
                     </plugin>
-
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
-                        <configuration>
-                            <useAgent>false</useAgent>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-
-                    <plugin>
-                        <groupId>de.jutzig</groupId>
-                        <artifactId>github-release-plugin</artifactId>
-                        <version>1.1.1</version>
-                        <executions>
-                            <execution>
-                                <id>github-upload</id>
-                                <phase>deploy</phase>
-                                <goals>
-                                    <goal>release</goal>
-                                </goals>
-                                <inherited>false</inherited>
-                                <configuration>
-                                    <description>${project.description}</description>
-                                    <releaseName>v${project.version}</releaseName>
-                                    <prerelease>false</prerelease>
-                                    <tag>v${project.version}</tag>
-                                    <fileSets>
-                                        <fileSet>
-                                            <directory>${project.build.directory}</directory>
-                                            <includes>
-                                                <include>${project.artifactId}*.jar</include>
-                                                <include>${project.artifactId}*.pom</include>
-                                            </includes>
-                                        </fileSet>
-                                    </fileSets>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-
-
                 </plugins>
             </build>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -168,9 +168,15 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>ecm4u-snapshots</id>
+            <name>ecm4u Snapshots</name>
+            <url>http://esb-dev.ecm4u.intra:9091/repository/ecm4u-snapshots/</url>
         </snapshotRepository>
+        <repository>
+            <id>ecm4u-releases</id>
+            <name>ecm4u Snapshots</name>
+            <url>http://esb-dev.ecm4u.intra:9091/repository/ecm4u-releases/</url>
+        </repository>
     </distributionManagement>
 
     <build>
@@ -464,9 +470,48 @@
 
     <repositories>
         <repository>
+            <id>ecm4u-snapshots</id>
+            <name>ecm4u Snapshots</name>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+                <checksumPolicy>warn</checksumPolicy>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+                <updatePolicy>never</updatePolicy>
+                <checksumPolicy>fail</checksumPolicy>
+            </releases>
+            <url>http://esb-dev.ecm4u.intra:9091/repository/ecm4u-snapshots/</url>
+        </repository>
+        
+        <repository>
+            <id>ecm4u-releases</id>
+            <name>ecm4u Releases</name>
+            <snapshots>
+                <enabled>false</enabled>
+                <updatePolicy>never</updatePolicy>
+                <checksumPolicy>warn</checksumPolicy>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+                <checksumPolicy>fail</checksumPolicy>
+            </releases>
+            <url>http://esb-dev.ecm4u.intra:9091/repository/ecm4u-releases/</url>
+        </repository>
+        
+        <repository>
+            <id>3rd-party</id>
+            <name>3rd party modules</name>
+            <url>http://esb-dev.ecm4u.intra:9091/repository/3rd-party/</url>
+        </repository>
+        
+        <repository>
             <id>alfresco-public</id>
             <url>https://artifacts.alfresco.com/nexus/content/groups/public</url>
         </repository>
+        
         <repository>
             <id>alfresco-public-snapshots</id>
             <url>https://artifacts.alfresco.com/nexus/content/groups/public-snapshots</url>
@@ -475,10 +520,10 @@
                 <updatePolicy>daily</updatePolicy>
             </snapshots>
         </repository>
-        <!-- Alfresco Enterprise Edition Artifacts, put username/pwd for server in settings.xml -->
+        
         <repository>
-            <id>alfresco-private-repository</id>
-            <url>https://artifacts.alfresco.com/nexus/content/groups/private</url>
+            <id>alfresco-private</id>
+            <url>http://esb-dev.ecm4u.intra:9091/repository/alfresco-private/</url>
         </repository>
     </repositories>
     <pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -43,46 +43,46 @@
     </developers>
 
     <properties>
-            <!-- Alfresco Maven Plugin version to use -->
-            <alfresco.sdk.version>3.0.0-beta-4</alfresco.sdk.version>
+        <!-- Alfresco Maven Plugin version to use -->
+        <alfresco.sdk.version>3.0.0-beta-4</alfresco.sdk.version>
 
-            <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-            <!-- Alfresco Data directory, which will contain:
-                    Content Store (i.e. the files we upload)
-                    Database (i.e. the metadata for the uploaded files)
-                    Search index (i.e. the indexed content and metadata)
-                 Configured in alfresco-global.properties with the 'dir.root' property.
-                    -->
-            <alfresco.data.location>./alf_data_dev</alfresco.data.location>
+        <!-- Alfresco Data directory, which will contain:
+        Content Store (i.e. the files we upload)
+        Database (i.e. the metadata for the uploaded files)
+        Search index (i.e. the indexed content and metadata)
+     Configured in alfresco-global.properties with the 'dir.root' property.
+        -->
+        <alfresco.data.location>./alf_data_dev</alfresco.data.location>
 
-            <!-- Duplicated with alfresco.solrHome in the plugin, we need them out here to do filtering -->
-            <solr.home>${alfresco.data.location}/solr</solr.home>
-            <solr.model.dir>${solr.home}/alfrescoModels</solr.model.dir>
-            <solr.content.dir>${solr.home}/index</solr.content.dir>
+        <!-- Duplicated with alfresco.solrHome in the plugin, we need them out here to do filtering -->
+        <solr.home>${alfresco.data.location}/solr</solr.home>
+        <solr.model.dir>${solr.home}/alfrescoModels</solr.model.dir>
+        <solr.content.dir>${solr.home}/index</solr.content.dir>
 
-            <!-- Properties used in dependency declarations, you don't need to change these -->
-            <alfresco.groupId>org.alfresco</alfresco.groupId>
-            <!-- Platform WAR artifact, change to 'alfresco-enterprise' if using Enterprise Edition -->
-            <alfresco.platform.war.artifactId>alfresco-platform</alfresco.platform.war.artifactId>
+        <!-- Properties used in dependency declarations, you don't need to change these -->
+        <alfresco.groupId>org.alfresco</alfresco.groupId>
+        <!-- Platform WAR artifact, change to 'alfresco-enterprise' if using Enterprise Edition -->
+        <alfresco.platform.war.artifactId>alfresco-platform</alfresco.platform.war.artifactId>
 
-            <!-- Alfresco Platform webapp version, this is the original Alfresco webapp that will be
-                customized and then deployed and run by the tomcat maven plugin when
-                executing for example $ mvn clean install alfresco:run -->
-            <alfresco.platform.version>5.2.b-EA</alfresco.platform.version>
-            <!-- Alfresco Share version, so we can bring in correct alfresco-share-services artifact -->
-            <alfresco.share.version>5.2.a-EA</alfresco.share.version>
+        <!-- Alfresco Platform webapp version, this is the original Alfresco webapp that will be
+        customized and then deployed and run by the tomcat maven plugin when
+        executing for example $ mvn clean install alfresco:run -->
+        <alfresco.platform.version>5.2.b-EA</alfresco.platform.version>
+        <!-- Alfresco Share version, so we can bring in correct alfresco-share-services artifact -->
+        <alfresco.share.version>5.2.a-EA</alfresco.share.version>
 
-            <!-- JRebel Hot reloading of classpath stuff and web resource stuff -->
-            <jrebel.version>1.1.6</jrebel.version>
+        <!-- JRebel Hot reloading of classpath stuff and web resource stuff -->
+        <jrebel.version>1.1.6</jrebel.version>
 
-            <!-- Environment to use, Alfresco Maven Plugin will
-                 copy alfresco-global-*.properties files from this directory, such as src/test/properties/local -->
-            <env>local</env>
+        <!-- Environment to use, Alfresco Maven Plugin will
+        copy alfresco-global-*.properties files from this directory, such as src/test/properties/local -->
+        <env>local</env>
 
-            <!-- Compile with Java 7, default is 5 -->
-            <maven.compiler.source>1.8</maven.compiler.source>
-            <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- Compile with Java 7, default is 5 -->
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
 
     </properties>
 
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>${alfresco.groupId}</groupId>
             <artifactId>alfresco-repository</artifactId>
-	    <scope>provided</scope>
+            <scope>provided</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.springframework/spring-test -->
         <dependency>
@@ -166,13 +166,13 @@
     <distributionManagement>
         <snapshotRepository>
             <id>ecm4u-snapshots</id>
-            <name>ecm4u Snapshots</name>
-            <url>http://esb-dev.ecm4u.intra:9091/repository/ecm4u-snapshots/</url>
+            <name>3rd Party Snapshots</name>
+            <url>http://esb-dev.ecm4u.intra:9091/repository/3rd-party-snapshots/</url>
         </snapshotRepository>
         <repository>
             <id>ecm4u-releases</id>
-            <name>ecm4u Snapshots</name>
-            <url>http://esb-dev.ecm4u.intra:9091/repository/ecm4u-releases/</url>
+            <name>3rd Party Releases</name>
+            <url>http://esb-dev.ecm4u.intra:9091/repository/3rd-party/</url>
         </repository>
     </distributionManagement>
 
@@ -180,9 +180,9 @@
         <plugins>
 
             <!--
-                The Alfresco Maven Plugin contains all the logic to run the extension
-                in an embedded Tomcat with the H2 database.
-                -->
+            The Alfresco Maven Plugin contains all the logic to run the extension
+            in an embedded Tomcat with the H2 database.
+            -->
             <plugin>
                 <groupId>org.alfresco.maven.plugin</groupId>
                 <artifactId>alfresco-maven-plugin</artifactId>
@@ -201,9 +201,9 @@
                     <enableShare>true</enableShare>
 
                     <!--
-                       JARs and AMPs that should be overlayed/applied to the Platform/Repository WAR
-                       (i.e. alfresco.war)
-                       -->
+                    JARs and AMPs that should be overlayed/applied to the Platform/Repository WAR
+                    (i.e. alfresco.war)
+                    -->
                     <platformModules>
                         <!-- This AMP is needed if we are going to access the platform webapp from a Share webapp -->
                         <moduleDependency>
@@ -225,7 +225,7 @@
                             <artifactId>ootbee-support-tools-repo</artifactId>
                             <version>0.0.1.0-SNAPSHOT</version>
                             <type>amp</type>
-                         </moduleDependency>
+                        </moduleDependency>
 
 
                         <!-- Bring in this JAR project, need to be included here, otherwise resources from META-INF
@@ -291,7 +291,7 @@
                 </executions>
                 <configuration>
                     <!-- For more information about how to configure JRebel plugin see:
-                         http://manuals.zeroturnaround.com/jrebel/standalone/maven.html#maven-rebel-xml -->
+                    http://manuals.zeroturnaround.com/jrebel/standalone/maven.html#maven-rebel-xml -->
                     <classpath>
                         <fallback>all</fallback>
                         <resources>
@@ -432,6 +432,17 @@
                 <checksumPolicy>fail</checksumPolicy>
             </releases>
             <url>http://esb-dev.ecm4u.intra:9091/repository/ecm4u-releases/</url>
+        </repository>
+
+        <repository>
+            <id>3rd-party-snapshots</id>
+            <name>3rd Party Snapshots</name>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+                <checksumPolicy>warn</checksumPolicy>
+            </snapshots>
+            <url>http://esb-dev.ecm4u.intra:9091/repository/3rd-party-snapshots/</url>
         </repository>
         
         <repository>

--- a/src/main/java/de/jgoldhammer/alfresco/jscript/batch/BatchScriptFacade.java
+++ b/src/main/java/de/jgoldhammer/alfresco/jscript/batch/BatchScriptFacade.java
@@ -22,6 +22,7 @@ import org.springframework.extensions.webscripts.annotation.ScriptMethodType;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import org.mozilla.javascript.NativeJavaObject;
 
 /**
  * fascade to a de.jgoldhammer.alfresco.jscript.batch processor implementation.
@@ -172,7 +173,11 @@ public class BatchScriptFacade extends BaseProcessorExtension implements Scopeab
 		List<NodeRef> nodes = new ArrayList<NodeRef>();
 		for (Object id : scriptNodes.getIds()) {
 			int index = (Integer) id;
-			ScriptNode scriptNode = (ScriptNode) scriptNodes.get(index, null);
+                        Object obj = scriptNodes.get(index);
+                        if (obj instanceof NativeJavaObject) {
+                            obj = ((NativeJavaObject) obj).unwrap();
+                        }
+			ScriptNode scriptNode = (ScriptNode) obj;
 			nodes.add(scriptNode.getNodeRef());
 		}
 		return nodes;


### PR DESCRIPTION
Fixes #16 by unwrapping a `NativeJavaObject` before casting to `ScriptNode`.

Please only merge the changes from 2017-10-11, ignore the old stuff.